### PR TITLE
Tolerate unexpected query arguments

### DIFF
--- a/src/chrome/pdf.js
+++ b/src/chrome/pdf.js
@@ -25,7 +25,10 @@ const defaultPrintOptions = {
 
 function cleanPrintOptionValue (type, value) {
   const types = { string: String, number: Number, boolean: Boolean }
-  return types[type](value)
+  if (type in types)
+    return types[type](value)
+  else
+    return value
 }
 
 export function makePrintOptions (options = {}) {


### PR DESCRIPTION
The pdf handler extracts `url` and passes all the remaining query
arguments to `makePrintOptions`. This broke when the handler was
called with other query arguments than those in
defaultPrintOptions. This was a problem when using orca-pdfgen with
the `aws_iam` authorizer, for the signv4 query
arguments (X-Aws-Credential, etc.) would be passed through to
orca-pdfgen's handler.

This commit makes cleanPrintOptionValue return the value unchanged if
the type is not one that cleanPrintOptionValue knows how to coerce.