### PR TITLE
Make upgraded Babel actually work

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
   "devDependencies": {
     "@babel/core": "^7.7.2",
     "@babel/node": "^7.7.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/polyfill": "^7.7.0",
     "@babel/preset-env": "^7.7.1",
     "@babel/register": "^7.7.0",
     "ava": "^2.4.0",
-    "serverless": "^1.40.0",
+    "babel-loader": "^8.0.6",
     "serverless-plugin-chrome": "^1.0.0-55",
-    "serverless-webpack": "4.0.0",
+    "serverless-webpack": "^4.0.0",
     "webpack": "3.8.1"
   },
   "ava": {
@@ -57,6 +58,9 @@
   "babel": {
     "presets": [
       "@babel/preset-env"
+    ],
+    "plugins": [
+      "@babel/plugin-proposal-object-rest-spread"
     ]
   }
 }

--- a/src/handlers/pdf.js
+++ b/src/handlers/pdf.js
@@ -5,6 +5,7 @@
 //
 //
 //
+import '@babel/polyfill'
 import log from '../utils/log'
 import pdf, { makePrintOptions } from '../chrome/pdf'
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,10 +11,14 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        loader: 'babel-loader',
         exclude: /node_modules/,
-        options: {
-          cacheDirectory: true,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            cacheDirectory: true,
+            presets: ['@babel/preset-env'],
+            plugins: ['@babel/plugin-proposal-object-rest-spread']
+          }
         },
       },
       { test: /\.json$/, loader: 'json-loader' },


### PR DESCRIPTION
More incomprehensible Babel stuff to make webpack run and the
resulting Lambda function actually work. This should have been done in
https://github.com/ccjmne/orca-pdfgen/pull/3.