### PR TITLE
Set Content-Disposition header with filename

### DIFF
--- a/src/handlers/pdf.js
+++ b/src/handlers/pdf.js
@@ -8,6 +8,15 @@
 import log from '../utils/log'
 import pdf, { makePrintOptions } from '../chrome/pdf'
 
+export function computePdfFilename(url) {
+  const URL = require('url').URL
+  return decodeURIComponent(new URL(url).pathname.
+    replace(/\/$/, '').
+    replace(/.*\//, '')).
+    replace(/\.html$/, '').
+    replace(/$/, '.pdf')
+}
+
 export default async function handler (event, context, callback) {
   const queryStringParameters = event.queryStringParameters || {}
   const {
@@ -30,14 +39,21 @@ export default async function handler (event, context, callback) {
 
   log(`Chromium took ${Date.now() - startTime}ms to load URL and render PDF.`)
 
+  var headers = {
+    'Content-Type': 'application/pdf'
+  }
+
+  // Ask browsers to save using a name that is based on the URL and not just `pdf.pdf`.
+  const pdfFilename = computePdfFilename(url);
+  if (pdfFilename.indexOf('"') == -1)
+    headers['Content-Disposition'] =  'inline; filename="' + pdfFilename + '"'
+
   // TODO: handle cases where the response is > 10MB
   // with saving to S3 or something since API Gateway has a body limit of 10MB
   return callback(null, {
     statusCode: 200,
     body: data,
     isBase64Encoded: true,
-    headers: {
-      'Content-Type': 'application/pdf',
-    },
+    headers: headers
   })
 }

--- a/src/handlers/pdf.test.js
+++ b/src/handlers/pdf.test.js
@@ -1,10 +1,30 @@
 import test from 'ava'
-import handler from '../handlers/pdf'
+import handler, { computePdfFilename } from '../handlers/pdf'
 
 const testUrl = 'https://github.com/adieuadieu'
 const testEvent = {
   queryStringParameters: { url: testUrl },
 }
+
+test('computePdfFilename replaces html with pdf', t => {
+  t.is(computePdfFilename('https://example.com/Bar.html'), 'Bar.pdf')
+})
+
+test('computePdfFilename removes directories from pth', t => {
+  t.is(computePdfFilename('https://example.com/foo/bar/Baz.html'), 'Baz.pdf')
+})
+
+test('computePdfFilename appends pdf to non-HTML name', t => {
+  t.is(computePdfFilename('https://example.com/foo/Bar'), 'Bar.pdf')
+})
+
+test('computePdfFilename uses the last directory if the path does not have a filename', t => {
+  t.is(computePdfFilename('https://example.com/foo/bar/'), 'bar.pdf')
+})
+
+test('computePdfFilename decodes the filename', t => {
+  t.is(computePdfFilename('https://example.com/foo/bar%20baz.html'), 'bar baz.pdf')
+})
 
 test('PDF handler', async (t) => {
   await t.notThrows(async () => {


### PR DESCRIPTION
This makes browsers use the filename when saving the PDF